### PR TITLE
Implement deterministic team matching recommendations

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -39,6 +39,21 @@ A FastAPI application that enables Slalom consultants to register their capabili
 | GET    | `/capabilities`                                                   | Get all capabilities with details and current consultant assignments |
 | POST   | `/capabilities/{capability_name}/register?email=consultant@slalom.com` | Register consultant for a capability                     |
 | DELETE | `/capabilities/{capability_name}/unregister?email=consultant@slalom.com` | Unregister consultant from a capability              |
+| GET    | `/capabilities/{capability_name}/recommendations?top_n=5` | Get ranked consultant recommendations with explainability |
+
+## Team Matching Scoring Model
+
+The recommendations endpoint uses deterministic weighted scoring (no ML) so ranking is transparent and repeatable.
+
+| Factor | Weight | Details |
+| ------ | ------ | ------- |
+| Skill level match | 35 | Compares consultant skill level to capability target level |
+| Certification overlap | 25 | Scores overlap between consultant and capability certifications |
+| Availability | 20 | Scales consultant available hours/week up to 20h |
+| Practice area alignment | 10 | Full points when practice area matches |
+| Industry overlap | 10 | Partial score based on shared industry verticals |
+
+Each recommendation includes an `explainability` object with per-factor points and rationale.
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -104,6 +104,280 @@ capabilities = {
     }
 }
 
+# In-memory consultant profiles used for team matching recommendations
+consultants = {
+    "alice.smith@slalom.com": {
+        "name": "Alice Smith",
+        "practice_area": "Technology",
+        "skill_level": "Expert",
+        "certifications": ["AWS Solutions Architect", "Kubernetes Admin"],
+        "industry_verticals": ["Healthcare", "Financial Services"],
+        "availability": 12
+    },
+    "bob.johnson@slalom.com": {
+        "name": "Bob Johnson",
+        "practice_area": "Technology",
+        "skill_level": "Advanced",
+        "certifications": ["Azure Architect Expert"],
+        "industry_verticals": ["Retail", "Financial Services"],
+        "availability": 10
+    },
+    "emma.davis@slalom.com": {
+        "name": "Emma Davis",
+        "practice_area": "Technology",
+        "skill_level": "Expert",
+        "certifications": ["Tableau Desktop Specialist", "Power BI Expert"],
+        "industry_verticals": ["Retail", "Manufacturing"],
+        "availability": 14
+    },
+    "sophia.wilson@slalom.com": {
+        "name": "Sophia Wilson",
+        "practice_area": "Technology",
+        "skill_level": "Advanced",
+        "certifications": ["Google Analytics"],
+        "industry_verticals": ["Healthcare", "Retail"],
+        "availability": 8
+    },
+    "john.brown@slalom.com": {
+        "name": "John Brown",
+        "practice_area": "Technology",
+        "skill_level": "Advanced",
+        "certifications": ["Docker Certified Associate", "Jenkins Certified"],
+        "industry_verticals": ["Technology", "Financial Services"],
+        "availability": 9
+    },
+    "olivia.taylor@slalom.com": {
+        "name": "Olivia Taylor",
+        "practice_area": "Technology",
+        "skill_level": "Proficient",
+        "certifications": ["Kubernetes Admin"],
+        "industry_verticals": ["Technology", "Healthcare"],
+        "availability": 15
+    },
+    "liam.anderson@slalom.com": {
+        "name": "Liam Anderson",
+        "practice_area": "Strategy",
+        "skill_level": "Expert",
+        "certifications": ["Digital Transformation Certificate"],
+        "industry_verticals": ["Government", "Healthcare"],
+        "availability": 11
+    },
+    "noah.martinez@slalom.com": {
+        "name": "Noah Martinez",
+        "practice_area": "Strategy",
+        "skill_level": "Advanced",
+        "certifications": ["Agile Certified Practitioner"],
+        "industry_verticals": ["Financial Services", "Government"],
+        "availability": 12
+    },
+    "ava.garcia@slalom.com": {
+        "name": "Ava Garcia",
+        "practice_area": "Operations",
+        "skill_level": "Expert",
+        "certifications": ["Prosci Certified", "Lean Six Sigma Black Belt"],
+        "industry_verticals": ["Healthcare", "Manufacturing"],
+        "availability": 7
+    },
+    "mia.rodriguez@slalom.com": {
+        "name": "Mia Rodriguez",
+        "practice_area": "Operations",
+        "skill_level": "Advanced",
+        "certifications": ["Prosci Certified"],
+        "industry_verticals": ["Government", "Manufacturing"],
+        "availability": 13
+    },
+    "amelia.lee@slalom.com": {
+        "name": "Amelia Lee",
+        "practice_area": "Technology",
+        "skill_level": "Advanced",
+        "certifications": ["Adobe Certified Expert", "Google UX Design Certificate"],
+        "industry_verticals": ["Retail", "Technology"],
+        "availability": 16
+    },
+    "harper.white@slalom.com": {
+        "name": "Harper White",
+        "practice_area": "Technology",
+        "skill_level": "Proficient",
+        "certifications": ["Google UX Design Certificate"],
+        "industry_verticals": ["Healthcare", "Retail"],
+        "availability": 18
+    },
+    "ella.clark@slalom.com": {
+        "name": "Ella Clark",
+        "practice_area": "Technology",
+        "skill_level": "Expert",
+        "certifications": ["CISSP", "CISM"],
+        "industry_verticals": ["Financial Services", "Government"],
+        "availability": 6
+    },
+    "scarlett.lewis@slalom.com": {
+        "name": "Scarlett Lewis",
+        "practice_area": "Technology",
+        "skill_level": "Advanced",
+        "certifications": ["CompTIA Security+"],
+        "industry_verticals": ["Healthcare", "Government"],
+        "availability": 12
+    },
+    "james.walker@slalom.com": {
+        "name": "James Walker",
+        "practice_area": "Technology",
+        "skill_level": "Expert",
+        "certifications": ["Microsoft BI Certification", "Power BI Expert"],
+        "industry_verticals": ["Retail", "Financial Services"],
+        "availability": 10
+    },
+    "benjamin.hall@slalom.com": {
+        "name": "Benjamin Hall",
+        "practice_area": "Technology",
+        "skill_level": "Advanced",
+        "certifications": ["Qlik Sense Certified"],
+        "industry_verticals": ["Manufacturing", "Retail"],
+        "availability": 14
+    },
+    "charlotte.young@slalom.com": {
+        "name": "Charlotte Young",
+        "practice_area": "Operations",
+        "skill_level": "Expert",
+        "certifications": ["Certified Scrum Master", "SAFe Agilist"],
+        "industry_verticals": ["Technology", "Healthcare"],
+        "availability": 10
+    },
+    "henry.king@slalom.com": {
+        "name": "Henry King",
+        "practice_area": "Operations",
+        "skill_level": "Advanced",
+        "certifications": ["ICAgile Certified"],
+        "industry_verticals": ["Financial Services", "Technology"],
+        "availability": 15
+    },
+    "zoe.thomas@slalom.com": {
+        "name": "Zoe Thomas",
+        "practice_area": "Technology",
+        "skill_level": "Expert",
+        "certifications": ["AWS Solutions Architect", "Azure Architect Expert"],
+        "industry_verticals": ["Healthcare", "Retail", "Financial Services"],
+        "availability": 20
+    },
+    "ethan.moore@slalom.com": {
+        "name": "Ethan Moore",
+        "practice_area": "Technology",
+        "skill_level": "Proficient",
+        "certifications": ["Tableau Desktop Specialist"],
+        "industry_verticals": ["Retail", "Healthcare"],
+        "availability": 20
+    }
+}
+
+
+SCORE_WEIGHTS = {
+    "skill_level": 35,
+    "certifications": 25,
+    "availability": 20,
+    "practice_area": 10,
+    "industry_overlap": 10,
+}
+
+
+SKILL_LEVEL_RANK = {
+    "Emerging": 1,
+    "Proficient": 2,
+    "Advanced": 3,
+    "Expert": 4,
+}
+
+
+def _score_skill_level(capability: dict, consultant: dict) -> tuple[float, str]:
+    target_level = max(
+        capability.get("skill_levels", ["Emerging"]),
+        key=lambda level: SKILL_LEVEL_RANK.get(level, 0)
+    )
+    target_rank = SKILL_LEVEL_RANK.get(target_level, 1)
+    consultant_rank = SKILL_LEVEL_RANK.get(consultant.get("skill_level", "Emerging"), 1)
+    ratio = min(consultant_rank / max(target_rank, 1), 1)
+    points = SCORE_WEIGHTS["skill_level"] * ratio
+    reason = (
+        f"Skill level {consultant.get('skill_level', 'Emerging')} vs target {target_level}"
+    )
+    return points, reason
+
+
+def _score_certifications(capability: dict, consultant: dict) -> tuple[float, str]:
+    required = set(capability.get("certifications", []))
+    candidate = set(consultant.get("certifications", []))
+    if not required:
+        return SCORE_WEIGHTS["certifications"], "No required certifications for capability"
+
+    overlap = required.intersection(candidate)
+    ratio = len(overlap) / len(required)
+    points = SCORE_WEIGHTS["certifications"] * ratio
+    reason = f"Certification overlap {len(overlap)}/{len(required)}"
+    return points, reason
+
+
+def _score_availability(consultant: dict) -> tuple[float, str]:
+    availability = max(consultant.get("availability", 0), 0)
+    ratio = min(availability / 20, 1)
+    points = SCORE_WEIGHTS["availability"] * ratio
+    reason = f"Availability {availability}h/week"
+    return points, reason
+
+
+def _score_practice_area(capability: dict, consultant: dict) -> tuple[float, str]:
+    is_match = capability.get("practice_area") == consultant.get("practice_area")
+    points = SCORE_WEIGHTS["practice_area"] if is_match else 0
+    reason = "Practice area aligned" if is_match else "Practice area differs"
+    return points, reason
+
+
+def _score_industry_overlap(capability: dict, consultant: dict) -> tuple[float, str]:
+    target_industries = set(capability.get("industry_verticals", []))
+    consultant_industries = set(consultant.get("industry_verticals", []))
+    if not target_industries:
+        return SCORE_WEIGHTS["industry_overlap"], "No target industries set"
+
+    overlap = target_industries.intersection(consultant_industries)
+    ratio = len(overlap) / len(target_industries)
+    points = SCORE_WEIGHTS["industry_overlap"] * ratio
+    reason = f"Industry overlap {len(overlap)}/{len(target_industries)}"
+    return points, reason
+
+
+def get_recommendations(capability_name: str, top_n: int = 5) -> list[dict]:
+    if capability_name not in capabilities:
+        raise HTTPException(status_code=404, detail="Capability not found")
+
+    capability = capabilities[capability_name]
+    existing_team = set(capability.get("consultants", []))
+    recommendations = []
+
+    for email, profile in consultants.items():
+        if email in existing_team:
+            continue
+
+        skill_points, skill_reason = _score_skill_level(capability, profile)
+        cert_points, cert_reason = _score_certifications(capability, profile)
+        avail_points, avail_reason = _score_availability(profile)
+        practice_points, practice_reason = _score_practice_area(capability, profile)
+        industry_points, industry_reason = _score_industry_overlap(capability, profile)
+
+        total_score = skill_points + cert_points + avail_points + practice_points + industry_points
+
+        recommendations.append({
+            "email": email,
+            "name": profile.get("name", email),
+            "score": round(total_score, 2),
+            "explainability": {
+                "skill_level": {"points": round(skill_points, 2), "reason": skill_reason},
+                "certifications": {"points": round(cert_points, 2), "reason": cert_reason},
+                "availability": {"points": round(avail_points, 2), "reason": avail_reason},
+                "practice_area": {"points": round(practice_points, 2), "reason": practice_reason},
+                "industry_overlap": {"points": round(industry_points, 2), "reason": industry_reason},
+            }
+        })
+
+    recommendations.sort(key=lambda item: item["score"], reverse=True)
+    return recommendations[:max(top_n, 1)]
+
 
 @app.get("/")
 def root():
@@ -113,6 +387,15 @@ def root():
 @app.get("/capabilities")
 def get_capabilities():
     return capabilities
+
+
+@app.get("/capabilities/{capability_name}/recommendations")
+def recommend_consultants(capability_name: str, top_n: int = 5):
+    return {
+        "capability": capability_name,
+        "weights": SCORE_WEIGHTS,
+        "recommendations": get_recommendations(capability_name=capability_name, top_n=top_n)
+    }
 
 
 @app.post("/capabilities/{capability_name}/register")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,6 +1,10 @@
 document.addEventListener("DOMContentLoaded", () => {
   const capabilitiesList = document.getElementById("capabilities-list");
   const capabilitySelect = document.getElementById("capability");
+  const matchingCapabilitySelect = document.getElementById("matching-capability");
+  const matchingForm = document.getElementById("matching-form");
+  const topNInput = document.getElementById("top-n");
+  const recommendationsList = document.getElementById("recommendations-list");
   const registerForm = document.getElementById("register-form");
   const messageDiv = document.getElementById("message");
 
@@ -14,6 +18,9 @@ document.addEventListener("DOMContentLoaded", () => {
       capabilitiesList.innerHTML = "";
 
       // Populate capabilities list
+      capabilitySelect.innerHTML = '<option value="">-- Select a capability --</option>';
+      matchingCapabilitySelect.innerHTML = '<option value="">-- Select a capability --</option>';
+
       Object.entries(capabilities).forEach(([name, details]) => {
         const capabilityCard = document.createElement("div");
         capabilityCard.className = "capability-card";
@@ -56,6 +63,11 @@ document.addEventListener("DOMContentLoaded", () => {
         option.value = name;
         option.textContent = name;
         capabilitySelect.appendChild(option);
+
+        const matchingOption = document.createElement("option");
+        matchingOption.value = name;
+        matchingOption.textContent = name;
+        matchingCapabilitySelect.appendChild(matchingOption);
       });
 
       // Add event listeners to delete buttons
@@ -68,6 +80,61 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error fetching capabilities:", error);
     }
   }
+
+  function renderRecommendations(payload) {
+    const recommendations = payload.recommendations || [];
+
+    if (recommendations.length === 0) {
+      recommendationsList.innerHTML = "<p><em>No available consultants to recommend for this capability.</em></p>";
+      return;
+    }
+
+    const cardsHTML = recommendations
+      .map((item, index) => {
+        const explain = item.explainability || {};
+        return `
+          <article class="recommendation-card">
+            <h4>#${index + 1} ${item.name}</h4>
+            <p><strong>Email:</strong> ${item.email}</p>
+            <p><strong>Match Score:</strong> ${item.score} / 100</p>
+            <div class="explainability-grid">
+              <p><strong>Skill:</strong> ${explain.skill_level?.points || 0} pts (${explain.skill_level?.reason || "N/A"})</p>
+              <p><strong>Certifications:</strong> ${explain.certifications?.points || 0} pts (${explain.certifications?.reason || "N/A"})</p>
+              <p><strong>Availability:</strong> ${explain.availability?.points || 0} pts (${explain.availability?.reason || "N/A"})</p>
+              <p><strong>Practice Area:</strong> ${explain.practice_area?.points || 0} pts (${explain.practice_area?.reason || "N/A"})</p>
+              <p><strong>Industry:</strong> ${explain.industry_overlap?.points || 0} pts (${explain.industry_overlap?.reason || "N/A"})</p>
+            </div>
+          </article>
+        `;
+      })
+      .join("");
+
+    recommendationsList.innerHTML = cardsHTML;
+  }
+
+  matchingForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const capability = matchingCapabilitySelect.value;
+    const topN = topNInput.value;
+
+    try {
+      const response = await fetch(
+        `/capabilities/${encodeURIComponent(capability)}/recommendations?top_n=${encodeURIComponent(topN)}`
+      );
+      const result = await response.json();
+
+      if (!response.ok) {
+        recommendationsList.innerHTML = `<p class="error">${result.detail || "Failed to load recommendations."}</p>`;
+        return;
+      }
+
+      renderRecommendations(result);
+    } catch (error) {
+      recommendationsList.innerHTML = "<p class=\"error\">Failed to load recommendations. Please try again.</p>";
+      console.error("Error fetching recommendations:", error);
+    }
+  });
 
   // Handle unregister functionality
   async function handleUnregister(event) {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -44,6 +44,26 @@
         </form>
         <div id="message" class="hidden"></div>
       </section>
+
+      <section id="matching-container">
+        <h3>Team Matching Recommendations</h3>
+        <form id="matching-form">
+          <div class="form-group">
+            <label for="matching-capability">Select Capability:</label>
+            <select id="matching-capability" required>
+              <option value="">-- Select a capability --</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="top-n">Number of recommendations:</label>
+            <input type="number" id="top-n" min="1" max="10" value="5" required />
+          </div>
+          <button type="submit">Get Recommendations</button>
+        </form>
+        <div id="recommendations-list" class="recommendations-list">
+          <p><em>Select a capability to view ranked consultant recommendations.</em></p>
+        </div>
+      </section>
     </main>
 
     <footer>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -218,6 +218,40 @@ button[type="submit"]:hover {
   border-radius: 4px;
 }
 
+#matching-container {
+  max-width: 1040px;
+}
+
+.recommendations-list {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.recommendation-card {
+  border: 1px solid #dce8f7;
+  border-radius: 8px;
+  padding: 12px;
+  background: #f9fcff;
+}
+
+.recommendation-card h4 {
+  color: #003d7a;
+  margin-bottom: 6px;
+}
+
+.recommendation-card p {
+  margin-bottom: 6px;
+}
+
+.explainability-grid {
+  margin-top: 8px;
+  border-top: 1px dashed #bfd4ec;
+  padding-top: 8px;
+  font-size: 0.92rem;
+}
+
 .success {
   background-color: #e8f5e9;
   color: #2e7d32;

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from app import get_recommendations  # noqa: E402
+
+
+class TeamMatchingTests(unittest.TestCase):
+    def test_returns_ranked_recommendations(self):
+        recommendations = get_recommendations("Cloud Architecture", top_n=5)
+
+        self.assertGreaterEqual(len(recommendations), 1)
+        scores = [item["score"] for item in recommendations]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_excludes_already_registered_consultants(self):
+        recommendations = get_recommendations("Cloud Architecture", top_n=20)
+        existing_team = {"alice.smith@slalom.com", "bob.johnson@slalom.com"}
+
+        for item in recommendations:
+            self.assertNotIn(item["email"], existing_team)
+
+    def test_limits_number_of_results(self):
+        recommendations = get_recommendations("Data Analytics", top_n=3)
+        self.assertEqual(len(recommendations), 3)
+
+    def test_explainability_fields_present(self):
+        recommendation = get_recommendations("DevOps Engineering", top_n=1)[0]
+        explainability = recommendation["explainability"]
+
+        self.assertIn("skill_level", explainability)
+        self.assertIn("certifications", explainability)
+        self.assertIn("availability", explainability)
+        self.assertIn("practice_area", explainability)
+        self.assertIn("industry_overlap", explainability)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements Issue #5 by adding deterministic consultant-to-capability matching with explainable scoring.

## What changed
- Added consultant profile dataset and weighted scoring engine
- Added new endpoint:
  - `GET /capabilities/{capability_name}/recommendations?top_n=5`
- Added frontend recommendations panel to request and display ranked matches
- Added explainability details per recommendation (factor points + rationale)
- Documented scoring model and endpoint in `src/README.md`
- Added unit tests for ranking, exclusion, limits, and explainability fields

## Scoring weights
- Skill level: 35
- Certifications: 25
- Availability: 20
- Practice area: 10
- Industry overlap: 10

## Validation
- Ran tests: `python -m unittest discover -s tests -v`
- Result: 4 passed

Closes #5